### PR TITLE
Feature: Supports Symfony ^6.0 and ^7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ common: &common
 
 
 jobs:
-  test74:
-    docker:
-      - image: cimg/php:7.4
-    <<: *common
   test80:
     docker:
       - image: cimg/php:8.0
@@ -27,6 +23,5 @@ workflows:
     version: 2
     build:
         jobs:
-            - test74
             - test80
             - test81

--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -31,10 +31,6 @@ class ExportCommand extends Command
         $this->exportManager->exportInVault();
         $io->success('Configuration successfully sealed in vault');
 
-        if (Kernel::VERSION_ID >= 50100) {
-            return Command::SUCCESS;
-        }
-
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -14,14 +14,8 @@ class ExportCommand extends Command
     protected static $defaultName = 'sherlockode:configuration:export';
     protected static $defaultDescription = 'Export configuration parameters to the vault';
 
-    /**
-     * @var ExportManagerInterface
-     */
-    private $exportManager;
+    private ExportManagerInterface $exportManager;
 
-    /**
-     * @param ExportManagerInterface $exportManager
-     */
     public function __construct(ExportManagerInterface $exportManager)
     {
         parent::__construct();

--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -3,17 +3,19 @@
 namespace Sherlockode\ConfigurationBundle\Command;
 
 use Sherlockode\ConfigurationBundle\Manager\ExportManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Kernel;
 
+#[AsCommand(
+    name: 'sherlockode:configuration:export',
+    description: 'Export configuration parameters to the vault.'
+)]
 class ExportCommand extends Command
 {
-    protected static $defaultName = 'sherlockode:configuration:export';
-    protected static $defaultDescription = 'Export configuration parameters to the vault';
-
     private ExportManagerInterface $exportManager;
 
     public function __construct(ExportManagerInterface $exportManager)

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -14,14 +14,8 @@ class ImportCommand extends Command
     protected static $defaultName = 'sherlockode:configuration:import';
     protected static $defaultDescription = 'Import configuration parameters from the vault';
 
-    /**
-     * @var ImportManagerInterface
-     */
-    private $importManager;
+    private ImportManagerInterface $importManager;
 
-    /**
-     * @param ImportManagerInterface $importManager
-     */
     public function __construct(ImportManagerInterface $importManager)
     {
         parent::__construct();

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -3,17 +3,19 @@
 namespace Sherlockode\ConfigurationBundle\Command;
 
 use Sherlockode\ConfigurationBundle\Manager\ImportManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Kernel;
 
+#[AsCommand(
+    name: 'sherlockode:configuration:import',
+    description: 'Import configuration parameters from the vault.'
+)]
 class ImportCommand extends Command
 {
-    protected static $defaultName = 'sherlockode:configuration:import';
-    protected static $defaultDescription = 'Import configuration parameters from the vault';
-
     private ImportManagerInterface $importManager;
 
     public function __construct(ImportManagerInterface $importManager)

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -31,10 +31,6 @@ class ImportCommand extends Command
         $this->importManager->importFromVault();
         $io->success('Configuration successfully imported from vault');
 
-        if (Kernel::VERSION_ID >= 50100) {
-            return Command::SUCCESS;
-        }
-
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/Controller/ParameterController.php
+++ b/Controller/ParameterController.php
@@ -29,75 +29,30 @@ use Twig\Error\SyntaxError;
  */
 class ParameterController
 {
-    /**
-     * @var ParameterManagerInterface
-     */
-    private $parameterManager;
+    private ParameterManagerInterface $parameterManager;
 
-    /**
-     * @var ExportManagerInterface
-     */
-    private $exportManager;
+    private ExportManagerInterface $exportManager;
 
-    /**
-     * @var ImportManagerInterface
-     */
-    private $importManager;
+    private ImportManagerInterface $importManager;
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
+    private RequestStack $requestStack;
 
-    /**
-     * @var FormFactoryInterface
-     */
-    private $formFactory;
+    private FormFactoryInterface $formFactory;
 
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $eventDispatcher;
+    private EventDispatcherInterface $eventDispatcher;
 
-    /**
-     * @var UrlGeneratorInterface
-     */
-    private $urlGenerator;
+    private UrlGeneratorInterface $urlGenerator;
 
-    /**
-     * @var Environment
-     */
-    private $twig;
+    private Environment $twig;
 
-    /**
-     * @var string
-     */
-    private $editFormTemplate;
+    private string $editFormTemplate;
 
-    /**
-     * @var string
-     */
-    private $importFormTemplate;
+    private string $importFormTemplate;
 
-    /**
-     * @var string
-     */
-    private $redirectAfterImportRoute;
+    private string $redirectAfterImportRoute;
 
     /**
      * ParameterController constructor.
-     *
-     * @param ParameterManagerInterface $parameterManager
-     * @param ExportManagerInterface    $exportManager
-     * @param ImportManagerInterface    $importManager
-     * @param EventDispatcherInterface  $eventDispatcher
-     * @param RequestStack              $requestStack
-     * @param FormFactoryInterface      $formFactory
-     * @param UrlGeneratorInterface     $urlGenerator
-     * @param Environment               $twig
-     * @param string                    $editFormTemplate
-     * @param string                    $importFormTemplate
-     * @param string                    $redirectAfterImportRoute
      */
     public function __construct(
         ParameterManagerInterface $parameterManager,
@@ -126,10 +81,6 @@ class ParameterController
     }
 
     /**
-     * @param Request $request
-     *
-     * @return Response
-     *
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
@@ -171,9 +122,6 @@ class ParameterController
         ]));
     }
 
-    /**
-     * @return Response
-     */
     public function exportAction(): Response
     {
         $response = new Response($this->exportManager->exportAsString());
@@ -187,10 +135,6 @@ class ParameterController
     }
 
     /**
-     * @param Request $request
-     *
-     * @return Response
-     *
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError

--- a/DependencyInjection/Compiler/FieldTypePass.php
+++ b/DependencyInjection/Compiler/FieldTypePass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class FieldTypePass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!class_exists('Doctrine\\ORM\\EntityManager')) {
             $container->removeDefinition('sherlockode_configuration.field.entity');

--- a/DependencyInjection/SherlockodeConfigurationExtension.php
+++ b/DependencyInjection/SherlockodeConfigurationExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class SherlockodeConfigurationExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/Event/PostSaveEvent.php
+++ b/Event/PostSaveEvent.php
@@ -9,9 +9,6 @@ class PostSaveEvent
     use ResponseEventTrait;
     use RequestEventTrait;
 
-    /**
-     * @param Request $request
-     */
     public function __construct(Request $request)
     {
         $this->request = $request;

--- a/Event/PreSaveEvent.php
+++ b/Event/PreSaveEvent.php
@@ -9,24 +9,15 @@ class PreSaveEvent
     use ResponseEventTrait;
     use RequestEventTrait;
 
-    /**
-     * @var array
-     */
-    private $parameters;
+    private array $parameters;
 
-    /**
-     * @param array $parameters
-     */
-    public function __construct(Request $request, $parameters)
+    public function __construct(Request $request, array $parameters)
     {
         $this->request = $request;
         $this->parameters = $parameters;
     }
 
-    /**
-     * @return array
-     */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }

--- a/Event/RequestEventTrait.php
+++ b/Event/RequestEventTrait.php
@@ -6,15 +6,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 trait RequestEventTrait
 {
-    /**
-     * @var Request
-     */
-    private $request;
+    private Request $request;
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }

--- a/Event/RequestEventTrait.php
+++ b/Event/RequestEventTrait.php
@@ -6,9 +6,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 trait RequestEventTrait
 {
-    private Request $request;
+    private ?Request $request = null;
 
-    public function getRequest(): Request
+    public function getRequest(): ?Request
     {
         return $this->request;
     }

--- a/Event/ResponseEventTrait.php
+++ b/Event/ResponseEventTrait.php
@@ -6,25 +6,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 trait ResponseEventTrait
 {
-    /**
-     * @var Response
-     */
-    private $response;
+    private Response $response;
 
-    /**
-     * @return Response
-     */
-    public function getResponse()
+    public function getResponse(): Response
     {
         return $this->response;
     }
 
-    /**
-     * @param Response $response
-     *
-     * @return $this
-     */
-    public function setResponse(Response $response)
+    public function setResponse(Response $response): self
     {
         $this->response = $response;
 

--- a/Event/ResponseEventTrait.php
+++ b/Event/ResponseEventTrait.php
@@ -6,14 +6,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 trait ResponseEventTrait
 {
-    private Response $response;
+    private ?Response $response = null;
 
-    public function getResponse(): Response
+    public function getResponse(): ?Response
     {
         return $this->response;
     }
 
-    public function setResponse(Response $response): self
+    public function setResponse(?Response $response): self
     {
         $this->response = $response;
 

--- a/FieldType/AbstractField.php
+++ b/FieldType/AbstractField.php
@@ -7,22 +7,12 @@ use Sherlockode\ConfigurationBundle\Transformer\TransformerInterface;
 
 abstract class AbstractField implements FieldTypeInterface
 {
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return array
-     */
-    public function getFormOptions(ParameterDefinition $definition)
+    public function getFormOptions(ParameterDefinition $definition): array
     {
         return [];
     }
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return TransformerInterface
-     */
-    public function getModelTransformer(ParameterDefinition $definition)
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
     {
         return null;
     }

--- a/FieldType/CheckboxField.php
+++ b/FieldType/CheckboxField.php
@@ -9,32 +9,24 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 class CheckboxField extends AbstractField
 {
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition)
+    public function getFormType(ParameterDefinition $definition): string
     {
         return CheckboxType::class;
     }
 
-    public function getFormOptions(ParameterDefinition $definition)
+    public function getFormOptions(ParameterDefinition $definition): array
     {
         return [
             'required' => $definition->getOption('required', false),
         ];
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'checkbox';
     }
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return TransformerInterface
-     */
-    public function getModelTransformer(ParameterDefinition $definition)
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
     {
         return new BooleanTransformer();
     }

--- a/FieldType/ChoiceField.php
+++ b/FieldType/ChoiceField.php
@@ -9,15 +9,12 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class ChoiceField extends AbstractField
 {
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition)
+    public function getFormType(ParameterDefinition $definition): string
     {
         return ChoiceType::class;
     }
 
-    public function getFormOptions(ParameterDefinition $definition)
+    public function getFormOptions(ParameterDefinition $definition): array
     {
         return [
             'choices' => $definition->getOption('choices', []),
@@ -27,17 +24,12 @@ class ChoiceField extends AbstractField
         ];
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'choice';
     }
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return TransformerInterface
-     */
-    public function getModelTransformer(ParameterDefinition $definition)
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
     {
         if ($definition->getOption('multiple', false)) {
             return new ArrayTransformer();

--- a/FieldType/DateTimeField.php
+++ b/FieldType/DateTimeField.php
@@ -9,25 +9,17 @@ use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 class DateTimeField extends AbstractField
 {
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition)
+    public function getFormType(ParameterDefinition $definition): string
     {
         return DateTimeType::class;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'datetime';
     }
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return TransformerInterface
-     */
-    public function getModelTransformer(ParameterDefinition $definition)
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
     {
         return new CallbackTransformer(
             function ($data) {

--- a/FieldType/EntityField.php
+++ b/FieldType/EntityField.php
@@ -5,6 +5,7 @@ namespace Sherlockode\ConfigurationBundle\FieldType;
 use Doctrine\ORM\EntityManagerInterface;
 use Sherlockode\ConfigurationBundle\Parameter\ParameterDefinition;
 use Sherlockode\ConfigurationBundle\Transformer\CallbackTransformer;
+use Sherlockode\ConfigurationBundle\Transformer\TransformerInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 
 class EntityField extends AbstractField

--- a/FieldType/EntityField.php
+++ b/FieldType/EntityField.php
@@ -9,28 +9,19 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 
 class EntityField extends AbstractField
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
-    /**
-     * @param EntityManagerInterface $em
-     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }
 
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition)
+    public function getFormType(ParameterDefinition $definition): string
     {
         return EntityType::class;
     }
 
-    public function getFormOptions(ParameterDefinition $definition)
+    public function getFormOptions(ParameterDefinition $definition): array
     {
         $options = [
             'class' => $definition->getOption('class'),
@@ -47,12 +38,12 @@ class EntityField extends AbstractField
         return $options;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'entity';
     }
 
-    public function getModelTransformer(ParameterDefinition $definition)
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
     {
         $class = $definition->getOption('class');
         $multiple = $definition->getOption('multiple');

--- a/FieldType/FieldTypeInterface.php
+++ b/FieldType/FieldTypeInterface.php
@@ -7,27 +7,11 @@ use Sherlockode\ConfigurationBundle\Transformer\TransformerInterface;
 
 interface FieldTypeInterface
 {
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition);
+    public function getFormType(ParameterDefinition $definition): string;
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return array
-     */
-    public function getFormOptions(ParameterDefinition $definition);
+    public function getFormOptions(ParameterDefinition $definition): array;
 
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return TransformerInterface
-     */
-    public function getModelTransformer(ParameterDefinition $definition);
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface;
 }

--- a/FieldType/ImageField.php
+++ b/FieldType/ImageField.php
@@ -9,25 +9,17 @@ use Sherlockode\ConfigurationBundle\Transformer\TransformerInterface;
 
 class ImageField extends AbstractField
 {
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition)
+    public function getFormType(ParameterDefinition $definition): string
     {
         return ImageType::class;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'image';
     }
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return TransformerInterface
-     */
-    public function getModelTransformer(ParameterDefinition $definition)
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
     {
         return new ArrayTransformer();
     }

--- a/FieldType/PasswordField.php
+++ b/FieldType/PasswordField.php
@@ -5,6 +5,7 @@ namespace Sherlockode\ConfigurationBundle\FieldType;
 use Doctrine\ORM\EntityManagerInterface;
 use Sherlockode\ConfigurationBundle\Parameter\ParameterDefinition;
 use Sherlockode\ConfigurationBundle\Transformer\CallbackTransformer;
+use Sherlockode\ConfigurationBundle\Transformer\TransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 
 class PasswordField extends AbstractField

--- a/FieldType/PasswordField.php
+++ b/FieldType/PasswordField.php
@@ -9,48 +9,27 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 
 class PasswordField extends AbstractField
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
-    /**
-     * @var string
-     */
-    private $parameterClass;
+    private string $parameterClass;
 
-    /**
-     * @param EntityManagerInterface $em
-     * @param string                 $parameterClass
-     */
-    public function __construct(EntityManagerInterface $em, $parameterClass)
+    public function __construct(EntityManagerInterface $em, string $parameterClass)
     {
         $this->em = $em;
         $this->parameterClass = $parameterClass;
     }
 
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition)
+    public function getFormType(ParameterDefinition $definition): string
     {
         return PasswordType::class;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'password';
     }
 
-    /**
-     * @param ParameterDefinition $definition
-     *
-     * @return CallbackTransformer
-     */
-    public function getModelTransformer(ParameterDefinition $definition)
+    public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
     {
         $parameter = $this->em->getRepository($this->parameterClass)->findOneBy(['path' => $definition->getPath()]);
         $currentValue = $parameter ? $parameter->getValue() : null;

--- a/FieldType/SimpleField.php
+++ b/FieldType/SimpleField.php
@@ -7,10 +7,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class SimpleField extends AbstractField
 {
-    /**
-     * @return string
-     */
-    public function getFormType(ParameterDefinition $definition)
+    public function getFormType(ParameterDefinition $definition): string
     {
         $formType = $definition->getOption('subtype', TextType::class);
 
@@ -21,7 +18,7 @@ class SimpleField extends AbstractField
         return $formType;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'simple';
     }

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -23,7 +23,7 @@ class ImageType extends AbstractType
         $this->uploadManager = $uploadManager;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('file', FileType::class, [
@@ -70,7 +70,7 @@ class ImageType extends AbstractType
         );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefault('translation_domain', 'SherlockodeConfigurationBundle');
     }
@@ -78,7 +78,7 @@ class ImageType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $source = '';
         $data = $form->getData();

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -16,10 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ImageType extends AbstractType
 {
-    /**
-     * @var UploadManagerInterface
-     */
-    private $uploadManager;
+    private UploadManagerInterface $uploadManager;
 
     public function __construct(UploadManagerInterface $uploadManager)
     {
@@ -73,9 +70,6 @@ class ImageType extends AbstractType
         );
     }
 
-    /**
-     * @param OptionsResolver $resolver
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefault('translation_domain', 'SherlockodeConfigurationBundle');
@@ -96,9 +90,6 @@ class ImageType extends AbstractType
 
     }
 
-    /**
-     * @return string
-     */
     public function getBlockPrefix(): string
     {
         return 'config_image';

--- a/Form/Type/ImportType.php
+++ b/Form/Type/ImportType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ImportType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('file', FileType::class, [

--- a/Form/Type/ImportType.php
+++ b/Form/Type/ImportType.php
@@ -10,10 +10,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ImportType extends AbstractType
 {
-    /**
-     * @param FormBuilderInterface $builder
-     * @param array                $options
-     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder

--- a/Form/Type/ParametersType.php
+++ b/Form/Type/ParametersType.php
@@ -13,20 +13,11 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class ParametersType extends AbstractType
 {
-    /**
-     * @var ConfigurationManagerInterface
-     */
-    private $configurationManager;
+    private ConfigurationManagerInterface $configurationManager;
 
-    /**
-     * @var FieldTypeManagerInterface
-     */
-    private $fieldTypeManager;
+    private FieldTypeManagerInterface $fieldTypeManager;
 
-    /**
-     * @var ConstraintManagerInterface
-     */
-    private $constraintManager;
+    private ConstraintManagerInterface $constraintManager;
 
     public function __construct(
         ConfigurationManagerInterface $configurationManager,

--- a/Form/Type/ParametersType.php
+++ b/Form/Type/ParametersType.php
@@ -29,7 +29,7 @@ class ParametersType extends AbstractType
         $this->constraintManager = $constraintManager;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         foreach ($this->configurationManager->getDefinedParameters() as $definition) {
             $field = $this->fieldTypeManager->getField($definition->getType());

--- a/Manager/ConfigurationManager.php
+++ b/Manager/ConfigurationManager.php
@@ -9,13 +9,9 @@ class ConfigurationManager implements ConfigurationManagerInterface
     /**
      * @var ParameterDefinition[]
      */
-    private $definitions;
+    private array $definitions;
 
-    /**
-     * @param array        $config
-     * @param string|false $translationDomain
-     */
-    public function __construct($config = [], $translationDomain = false)
+    public function __construct(array $config = [], string|false $translationDomain = false)
     {
         $this->definitions = $this->processConfiguration($config, $translationDomain);
     }
@@ -25,18 +21,15 @@ class ConfigurationManager implements ConfigurationManagerInterface
      *
      * @return ParameterDefinition[]
      */
-    public function getDefinedParameters()
+    public function getDefinedParameters(): array
     {
         return $this->definitions;
     }
 
     /**
-     * @param string $path
-     *
-     * @return ParameterDefinition
      * @throws \Exception
      */
-    public function get($path)
+    public function get(string $path): ParameterDefinition
     {
         if (!isset($this->definitions[$path])) {
             throw new \Exception(sprintf('Undefined parameter path "%s"', $path));
@@ -45,23 +38,15 @@ class ConfigurationManager implements ConfigurationManagerInterface
         return $this->definitions[$path];
     }
 
-    /**
-     * @param string $path
-     *
-     * @return bool
-     */
-    public function has($path)
+    public function has(string $path): bool
     {
         return isset($this->definitions[$path]);
     }
 
     /**
-     * @param array        $config
-     * @param string|false $translationDomain
-     *
      * @return ParameterDefinition[]
      */
-    private function processConfiguration($config, $translationDomain = false)
+    private function processConfiguration(array $config, string|false $translationDomain = false): array
     {
         $result = [];
         foreach ($config as $path => $data) {

--- a/Manager/ConfigurationManagerInterface.php
+++ b/Manager/ConfigurationManagerInterface.php
@@ -11,23 +11,15 @@ interface ConfigurationManagerInterface
      *
      * @return ParameterDefinition[]
      */
-    public function getDefinedParameters();
+    public function getDefinedParameters(): array;
 
     /**
      * Check a definition's existence
-     *
-     * @param string $path
-     *
-     * @return bool
      */
-    public function has($path);
+    public function has(string $path): bool;
 
     /**
      * Get a definition from a path
-     *
-     * @param string $path
-     *
-     * @return ParameterDefinition
      */
-    public function get($path);
+    public function get(string $path): ParameterDefinition;
 }

--- a/Manager/ConstraintManager.php
+++ b/Manager/ConstraintManager.php
@@ -7,11 +7,6 @@ use Symfony\Component\Validator\Mapping\Loader\AbstractLoader;
 
 class ConstraintManager implements ConstraintManagerInterface
 {
-    /**
-     * @param array $definition
-     *
-     * @return array
-     */
     public function getConstraints(array $definition): array
     {
         $constraints = [];
@@ -26,11 +21,6 @@ class ConstraintManager implements ConstraintManagerInterface
     }
 
     /**
-     * @param string     $fqcn
-     * @param array|null $args
-     *
-     * @return Constraint
-     *
      * @throws \Exception
      */
     private function create(string $fqcn, ?array $args): Constraint

--- a/Manager/ConstraintManagerInterface.php
+++ b/Manager/ConstraintManagerInterface.php
@@ -4,10 +4,5 @@ namespace Sherlockode\ConfigurationBundle\Manager;
 
 interface ConstraintManagerInterface
 {
-    /**
-     * @param array $definition
-     *
-     * @return array
-     */
     public function getConstraints(array $definition): array;
 }

--- a/Manager/ExportManager.php
+++ b/Manager/ExportManager.php
@@ -7,29 +7,16 @@ use Symfony\Component\Yaml\Yaml;
 
 class ExportManager implements ExportManagerInterface
 {
-    /**
-     * @var ParameterManagerInterface
-     */
-    private $parameterManager;
+    private ParameterManagerInterface $parameterManager;
 
-    /**
-     * @var AbstractVault
-     */
-    private $vault;
+    private AbstractVault $vault;
 
-    /**
-     * @param ParameterManagerInterface $parameterManager
-     * @param AbstractVault             $vault
-     */
     public function __construct(ParameterManagerInterface $parameterManager, AbstractVault $vault)
     {
         $this->parameterManager = $parameterManager;
         $this->vault = $vault;
     }
 
-    /**
-     * @return string
-     */
     public function exportAsString(): string
     {
         $parameters = [];
@@ -45,8 +32,6 @@ class ExportManager implements ExportManagerInterface
     }
 
     /**
-     * @return void
-     *
      * @throws \Exception
      */
     public function exportInVault(): void

--- a/Manager/ExportManagerInterface.php
+++ b/Manager/ExportManagerInterface.php
@@ -4,13 +4,7 @@ namespace Sherlockode\ConfigurationBundle\Manager;
 
 interface ExportManagerInterface
 {
-    /**
-     * @return string
-     */
     public function exportAsString(): string;
 
-    /**
-     * @return void
-     */
     public function exportInVault(): void;
 }

--- a/Manager/FieldTypeManager.php
+++ b/Manager/FieldTypeManager.php
@@ -9,19 +9,14 @@ class FieldTypeManager implements FieldTypeManagerInterface
     /**
      * @var FieldTypeInterface[]
      */
-    private $fieldTypes;
+    private array $fieldTypes;
 
     public function __construct()
     {
         $this->fieldTypes = [];
     }
 
-    /**
-     * @param FieldTypeInterface $fieldType
-     *
-     * @return $this
-     */
-    public function addFieldType(FieldTypeInterface $fieldType)
+    public function addFieldType(FieldTypeInterface $fieldType): self
     {
         $this->fieldTypes[$fieldType->getName()] = $fieldType;
 
@@ -29,12 +24,9 @@ class FieldTypeManager implements FieldTypeManagerInterface
     }
 
     /**
-     * @param string $type
-     *
-     * @return FieldTypeInterface
      * @throws \Exception
      */
-    public function getField($type)
+    public function getField(string $type): FieldTypeInterface
     {
         if (!isset($this->fieldTypes[$type])) {
             throw new \Exception(sprintf('Unknown parameter type "%s"', $type));

--- a/Manager/FieldTypeManagerInterface.php
+++ b/Manager/FieldTypeManagerInterface.php
@@ -6,17 +6,7 @@ use Sherlockode\ConfigurationBundle\FieldType\FieldTypeInterface;
 
 interface FieldTypeManagerInterface
 {
-    /**
-     * @param FieldTypeInterface $fieldType
-     *
-     * @return $this
-     */
-    public function addFieldType(FieldTypeInterface $fieldType);
+    public function addFieldType(FieldTypeInterface $fieldType): self;
 
-    /**
-     * @param string $type
-     *
-     * @return FieldTypeInterface
-     */
-    public function getField($type);
+    public function getField(string $type): FieldTypeInterface;
 }

--- a/Manager/ImportManager.php
+++ b/Manager/ImportManager.php
@@ -8,29 +8,16 @@ use Symfony\Component\Yaml\Yaml;
 
 class ImportManager implements ImportManagerInterface
 {
-    /**
-     * @var ParameterManagerInterface
-     */
-    private $parameterManager;
+    private ParameterManagerInterface $parameterManager;
 
-    /**
-     * @var AbstractVault
-     */
-    private $vault;
+    private AbstractVault $vault;
 
-    /**
-     * @param ParameterManagerInterface $parameterManager
-     * @param AbstractVault             $vault
-     */
     public function __construct(ParameterManagerInterface $parameterManager, AbstractVault $vault)
     {
         $this->parameterManager = $parameterManager;
         $this->vault = $vault;
     }
 
-    /**
-     * @param File $source
-     */
     public function import(File $source): void
     {
         $raw = Yaml::parseFile($source->getRealPath());
@@ -43,9 +30,6 @@ class ImportManager implements ImportManagerInterface
         unlink($source->getRealPath());
     }
 
-    /**
-     * @return void
-     */
     public function importFromVault(): void
     {
         foreach ($this->parameterManager->getAll() as $path => $value) {

--- a/Manager/ImportManagerInterface.php
+++ b/Manager/ImportManagerInterface.php
@@ -6,13 +6,7 @@ use Symfony\Component\HttpFoundation\File\File;
 
 interface ImportManagerInterface
 {
-    /**
-     * @param File $source
-     */
     public function import(File $source): void;
 
-    /**
-     * @return void
-     */
     public function importFromVault(): void;
 }

--- a/Manager/ParameterManager.php
+++ b/Manager/ParameterManager.php
@@ -169,7 +169,7 @@ class ParameterManager implements ParameterManagerInterface
         $this->loaded = true;
     }
 
-    public function getStringValue(string $path, mixed $value): string
+    public function getStringValue(string $path, mixed $value): ?string
     {
         $parameterConfig = $this->configurationManager->get($path);
         $fieldType = $this->fieldTypeManager->getField($parameterConfig->getType());
@@ -181,7 +181,7 @@ class ParameterManager implements ParameterManagerInterface
         return $value;
     }
 
-    public function getUserValue(string $path, string $value): mixed
+    public function getUserValue(string $path, ?string $value): mixed
     {
         $parameterDefinition = $this->configurationManager->get($path);
         $fieldType = $this->fieldTypeManager->getField($parameterDefinition->getType());

--- a/Manager/ParameterManager.php
+++ b/Manager/ParameterManager.php
@@ -10,67 +10,49 @@ use Sherlockode\ConfigurationBundle\Model\ParameterInterface;
  */
 class ParameterManager implements ParameterManagerInterface
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
     /**
      * Class name of the parameter entity
-     *
-     * @var string
      */
-    private $class;
+    private string $class;
 
     /**
      * List of parameter objects
      *
      * @var ParameterInterface[]
      */
-    private $parameters;
+    private array $parameters;
 
     /**
      * Keep track of the new objects for the save action
      *
      * @var ParameterInterface[]
      */
-    private $newParameters;
+    private array $newParameters;
 
     /**
      * Parameters with "real" types (not strings), ie. after transformation from the database
      *
      * Associative array with : path => value
-     *
-     * @var array
      */
-    private $data;
+    private array $data;
 
-    /**
-     * @var bool
-     */
-    private $loaded;
+    private bool $loaded;
 
     /**
      * @var ConfigurationManagerInterface[]
      */
-    private $configurationManager;
+    private array $configurationManager;
 
-    /**
-     * @var FieldTypeManagerInterface
-     */
-    private $fieldTypeManager;
+    private FieldTypeManagerInterface $fieldTypeManager;
 
     /**
      * ParameterManager constructor.
-     *
-     * @param EntityManagerInterface        $em
-     * @param string                        $class
-     * @param ConfigurationManagerInterface $configurationManager
-     * @param FieldTypeManagerInterface     $fieldTypeManager
      */
     public function __construct(
         EntityManagerInterface $em,
-        $class,
+        string $class,
         ConfigurationManagerInterface $configurationManager,
         FieldTypeManagerInterface $fieldTypeManager
     ) {
@@ -84,18 +66,12 @@ class ParameterManager implements ParameterManagerInterface
         $this->fieldTypeManager = $fieldTypeManager;
     }
 
-    /**
-     * @return string
-     */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
 
-    /**
-     * @return array
-     */
-    public function getAll()
+    public function getAll(): array
     {
         if (false === $this->loaded) {
             $this->loadParameters();
@@ -120,13 +96,7 @@ class ParameterManager implements ParameterManagerInterface
         return $this->data;
     }
 
-    /**
-     * @param string $path
-     * @param mixed  $default
-     *
-     * @return mixed
-     */
-    public function get($path, $default = null)
+    public function get(string $path, mixed $default = null): mixed
     {
         if (false === $this->loaded) {
             $this->loadParameters();
@@ -152,13 +122,7 @@ class ParameterManager implements ParameterManagerInterface
         return $value ?? $default;
     }
 
-    /**
-     * @param string $path
-     * @param mixed  $value
-     *
-     * @return $this
-     */
-    public function set($path, $value)
+    public function set(string $path, mixed $value): self
     {
         if (false === $this->loaded) {
             $this->loadParameters();
@@ -183,7 +147,7 @@ class ParameterManager implements ParameterManagerInterface
     /**
      * Save all parameters into the database
      */
-    public function save()
+    public function save(): void
     {
         foreach ($this->newParameters as $parameter) {
             $this->em->persist($parameter);
@@ -195,7 +159,7 @@ class ParameterManager implements ParameterManagerInterface
      * Load the parameters from the database
      * and transform their string value into the expected type
      */
-    private function loadParameters()
+    private function loadParameters(): void
     {
         $parameters = $this->em->getRepository($this->class)->findAll();
         /** @var ParameterInterface $parameter */
@@ -208,13 +172,7 @@ class ParameterManager implements ParameterManagerInterface
         $this->loaded = true;
     }
 
-    /**
-     * @param string $path
-     * @param mixed  $value
-     *
-     * @return string
-     */
-    public function getStringValue($path, $value)
+    public function getStringValue(string $path, mixed $value): string
     {
         $parameterConfig = $this->configurationManager->get($path);
         $fieldType = $this->fieldTypeManager->getField($parameterConfig->getType());
@@ -226,13 +184,7 @@ class ParameterManager implements ParameterManagerInterface
         return $value;
     }
 
-    /**
-     * @param string $path
-     * @param string $value
-     *
-     * @return mixed
-     */
-    public function getUserValue($path, $value)
+    public function getUserValue(string $path, string $value): mixed
     {
         $parameterDefinition = $this->configurationManager->get($path);
         $fieldType = $this->fieldTypeManager->getField($parameterDefinition->getType());

--- a/Manager/ParameterManager.php
+++ b/Manager/ParameterManager.php
@@ -40,10 +40,7 @@ class ParameterManager implements ParameterManagerInterface
 
     private bool $loaded;
 
-    /**
-     * @var ConfigurationManagerInterface[]
-     */
-    private array $configurationManager;
+    private ConfigurationManagerInterface $configurationManager;
 
     private FieldTypeManagerInterface $fieldTypeManager;
 

--- a/Manager/ParameterManagerInterface.php
+++ b/Manager/ParameterManagerInterface.php
@@ -8,33 +8,21 @@ interface ParameterManagerInterface
      * Get all parameter values
      *
      * Return an associative array as : path => value
-     *
-     * @return array
      */
-    public function getAll();
+    public function getAll(): array;
 
     /**
      * Save all parameters into the database
      */
-    public function save();
+    public function save(): void;
 
     /**
      * Get an existing parameter value for a given path
-     *
-     * @param string $path
-     * @param mixed  $default
-     *
-     * @return mixed
      */
-    public function get($path, $default = null);
+    public function get(string $path, mixed $default = null): mixed;
 
     /**
      * Set the value of a parameter at given path
-     *
-     * @param string $path
-     * @param mixed  $value
-     *
-     * @return $this
      */
-    public function set($path, $value);
+    public function set(string $path, mixed $value): self;
 }

--- a/Manager/ParameterManagerInterface.php
+++ b/Manager/ParameterManagerInterface.php
@@ -25,4 +25,14 @@ interface ParameterManagerInterface
      * Set the value of a parameter at given path
      */
     public function set(string $path, mixed $value): self;
+
+    /**
+     * Get value as string
+     */
+    public function getStringValue(string $path, mixed $value): ?string;
+
+    /**
+     * Get user value
+     */
+    public function getUserValue(string $path, string $value): mixed;
 }

--- a/Manager/UploadManager.php
+++ b/Manager/UploadManager.php
@@ -6,17 +6,11 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UploadManager implements UploadManagerInterface
 {
-    /**
-     * @var string
-     */
-    private $targetDir;
+    private string $targetDir;
 
-    /**
-     * @var string
-     */
-    private $webPath;
+    private string $webPath;
 
-    public function __construct($targetDir, $webPath)
+    public function __construct(string $targetDir, string $webPath)
     {
         $this->targetDir = $targetDir;
         $this->webPath = $webPath;
@@ -24,12 +18,8 @@ class UploadManager implements UploadManagerInterface
 
     /**
      * Upload file on server
-     *
-     * @param UploadedFile|null $file
-     *
-     * @return string
      */
-    public function upload(UploadedFile $file = null)
+    public function upload(?UploadedFile $file = null): string
     {
         if ($file === null) {
             return '';
@@ -43,10 +33,8 @@ class UploadManager implements UploadManagerInterface
 
     /**
      * Remove file
-     *
-     * @param string $filename
      */
-    public function remove($filename)
+    public function remove(string $filename): void
     {
         $filepath = $this->getFilePath($filename);
 
@@ -57,24 +45,15 @@ class UploadManager implements UploadManagerInterface
         unlink($filepath);
     }
 
-    /**
-     * @param string $filename
-     *
-     * @return string
-     */
-    public function getFilePath($filename)
+    public function getFilePath(string $filename): string
     {
         return $this->targetDir . DIRECTORY_SEPARATOR . $filename;
     }
 
     /**
      * Generate the filename to store on disk
-     *
-     * @param UploadedFile $file
-     *
-     * @return string
      */
-    private function generateFilename(UploadedFile $file)
+    private function generateFilename(UploadedFile $file): string
     {
         $extension = $file->getClientOriginalExtension();
         $filename = str_replace('.' . $extension, '', $file->getClientOriginalName());
@@ -84,7 +63,7 @@ class UploadManager implements UploadManagerInterface
         return $filename;
     }
 
-    public function resolveUri($filename)
+    public function resolveUri(string $filename): string
     {
         return $this->webPath . '/' . $filename;
     }

--- a/Manager/UploadManagerInterface.php
+++ b/Manager/UploadManagerInterface.php
@@ -6,29 +6,11 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 interface UploadManagerInterface
 {
-    /**
-     * @param UploadedFile|null $file
-     *
-     * @return string
-     */
-    public function upload(UploadedFile $file = null);
+    public function upload(?UploadedFile $file = null): string;
 
-    /**
-     * @param string $filename
-     */
-    public function remove($filename);
+    public function remove(string $filename): void;
 
-    /**
-     * @param string $filename
-     *
-     * @return string
-     */
-    public function resolveUri($filename);
+    public function resolveUri(string $filename): string;
 
-    /**
-     * @param string $filename
-     *
-     * @return string
-     */
-    public function getFilePath($filename);
+    public function getFilePath(string $filename): string;
 }

--- a/Model/Parameter.php
+++ b/Model/Parameter.php
@@ -8,7 +8,7 @@ class Parameter implements ParameterInterface
 
     protected string $path;
 
-    protected string $value;
+    protected ?string $value = null;
 
     public function getId(): int
     {
@@ -27,12 +27,12 @@ class Parameter implements ParameterInterface
         return $this;
     }
 
-    public function getValue(): string
+    public function getValue(): ?string
     {
         return $this->value;
     }
 
-    public function setValue(string $value): self
+    public function setValue(?string $value): self
     {
         $this->value = $value;
 

--- a/Model/Parameter.php
+++ b/Model/Parameter.php
@@ -4,63 +4,35 @@ namespace Sherlockode\ConfigurationBundle\Model;
 
 class Parameter implements ParameterInterface
 {
-    /**
-     * @var int
-     */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @var string
-     */
-    protected $path;
+    protected string $path;
 
-    /**
-     * @var string
-     */
-    protected $value;
+    protected string $value;
 
-    /**
-     * @return int
-     */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
 
-    /**
-     * @param string $path
-     *
-     * @return $this
-     */
-    public function setPath($path)
+    public function setPath(string $path): self
     {
         $this->path = $path;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }
 
-    /**
-     * @param string $value
-     *
-     * @return $this
-     */
-    public function setValue($value)
+    public function setValue(string $value): self
     {
         $this->value = $value;
 

--- a/Model/ParameterInterface.php
+++ b/Model/ParameterInterface.php
@@ -4,35 +4,17 @@ namespace Sherlockode\ConfigurationBundle\Model;
 
 interface ParameterInterface
 {
-    /**
-     * @return int
-     */
-    public function getId();
+    public function getId(): int;
 
-    /**
-     * @return string
-     */
-    public function getPath();
+    public function getPath(): string;
 
-    /**
-     * @param string $path
-     *
-     * @return $this
-     */
-    public function setPath($path);
+    public function setPath(string $path): self;
 
     /**
      * Return the value stored in the database.
      * This value is always a string. Use TransformerInterface for non-primary types
-     *
-     * @return string
      */
-    public function getValue();
+    public function getValue(): string;
 
-    /**
-     * @param string $value
-     *
-     * @return $this
-     */
-    public function setValue($value);
+    public function setValue(string $value): self;
 }

--- a/Model/ParameterInterface.php
+++ b/Model/ParameterInterface.php
@@ -14,7 +14,7 @@ interface ParameterInterface
      * Return the value stored in the database.
      * This value is always a string. Use TransformerInterface for non-primary types
      */
-    public function getValue(): string;
+    public function getValue(): ?string;
 
-    public function setValue(string $value): self;
+    public function setValue(?string $value): self;
 }

--- a/Parameter/ParameterDefinition.php
+++ b/Parameter/ParameterDefinition.php
@@ -4,43 +4,22 @@ namespace Sherlockode\ConfigurationBundle\Parameter;
 
 class ParameterDefinition
 {
-    /**
-     * @var string
-     */
-    private $path;
+    private string $path;
 
-    /**
-     * @var string
-     */
-    private $type;
+    private string $type;
 
-    /**
-     * @var string
-     */
-    private $label;
+    private string $label;
 
-    /**
-     * @var string
-     */
-    private $defaultValue;
+    private string $defaultValue;
 
-    /**
-     * @var string
-     */
-    private $translationDomain;
+    private string $translationDomain;
 
-    /**
-     * @var array
-     */
-    private $options;
+    private array $options;
 
     /**
      * ParameterDefinition constructor.
-     *
-     * @param string $path
-     * @param string $type
      */
-    public function __construct($path, $type)
+    public function __construct(string $path, string $type)
     {
         $this->path = $path;
         $this->type = $type;
@@ -48,78 +27,53 @@ class ParameterDefinition
         $this->label = $this->path;
     }
 
-    /**
-     * @return string
-     */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
 
-    /**
-     * @return string
-     */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
 
-    /**
-     * @param string $label
-     *
-     * @return $this
-     */
-    public function setLabel($label)
+    public function setLabel(string $label): self
     {
         $this->label = $label;
 
         return $this;
     }
 
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    public function getDefaultValue()
+    public function getDefaultValue(): string
     {
         return $this->defaultValue;
     }
 
-    public function setDefaultValue($defaultValue)
+    public function setDefaultValue($defaultValue): self
     {
         $this->defaultValue = $defaultValue;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTranslationDomain()
+    public function getTranslationDomain(): string
     {
         return $this->translationDomain;
     }
 
-    /**
-     * @param string $translationDomain
-     *
-     * @return $this
-     */
-    public function setTranslationDomain($translationDomain)
+    public function setTranslationDomain(string $translationDomain): self
     {
         $this->translationDomain = $translationDomain;
 
         return $this;
     }
 
-    /**
-     * @param string $optionName
-     * @param mixed  $default
-     *
-     * @return mixed
-     */
-    public function getOption($optionName, $default = null)
+    public function getOption(string $optionName, mixed $default = null): mixed
     {
         if (!isset($this->options[$optionName])) {
             return $default;
@@ -128,19 +82,15 @@ class ParameterDefinition
         return $this->options[$optionName];
     }
 
-    /**
-     * @return array
-     */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
 
-    /**
-     * @param array $options
-     */
-    public function setOptions(array $options)
+    public function setOptions(array $options): self
     {
         $this->options = $options;
+
+        return $this;
     }
 }

--- a/Parameter/ParameterDefinition.php
+++ b/Parameter/ParameterDefinition.php
@@ -10,7 +10,7 @@ class ParameterDefinition
 
     private string $label;
 
-    private string $defaultValue;
+    private ?string $defaultValue = null;
 
     private string $translationDomain;
 
@@ -49,12 +49,12 @@ class ParameterDefinition
         return $this->type;
     }
 
-    public function getDefaultValue(): string
+    public function getDefaultValue(): ?string
     {
         return $this->defaultValue;
     }
 
-    public function setDefaultValue($defaultValue): self
+    public function setDefaultValue(?string $defaultValue): self
     {
         $this->defaultValue = $defaultValue;
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class Parameter extends BaseParameter
     protected string $path;
 
     #[ORM\Column(name: 'value', type: 'text', nullable: true)]
-    protected string $value;
+    protected ?string $value = null;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The bundle also provides a `CallbackTransformer` that can be used for faster imp
 For instance handling an array can be done like this :
 
 ```php
-public function getModelTransformer(ParameterDefinition $definition)
+public function getModelTransformer(ParameterDefinition $definition): ?TransformerInterface
 {
     return new CallbackTransformer(
         function ($data) {

--- a/README.md
+++ b/README.md
@@ -46,28 +46,20 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Sherlockode\ConfigurationBundle\Model\Parameter as BaseParameter;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="parameter")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'parameter')]
 class Parameter extends BaseParameter
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    protected $id;
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    protected int $id;
 
-    /**
-     * @ORM\Column(name="path", type="string")
-     */
-    protected $path;
+    #[ORM\Column(name: 'path', type: 'string')]
+    protected string $path;
 
-    /**
-     * @ORM\Column(name="value", type="text", nullable=true)
-     */
-    protected $value;
+    #[ORM\Column(name: 'value', type: 'text', nullable: true)]
+    protected string $value;
 }
 ```
 

--- a/SherlockodeConfigurationBundle.php
+++ b/SherlockodeConfigurationBundle.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SherlockodeConfigurationBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new FieldTypePass());
     }

--- a/Twig/ParameterExtension.php
+++ b/Twig/ParameterExtension.php
@@ -8,30 +8,21 @@ use Twig\TwigFunction;
 
 class ParameterExtension extends AbstractExtension
 {
-    /**
-     * @var ParameterManagerInterface
-     */
-    private $parameterManager;
+    private ParameterManagerInterface $parameterManager;
 
     public function __construct(ParameterManagerInterface $parameterManager)
     {
         $this->parameterManager = $parameterManager;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('configuration_parameter', [$this, 'getParameterValue']),
         ];
     }
 
-    /**
-     * @param string $key
-     * @param mixed  $default
-     *
-     * @return mixed
-     */
-    public function getParameterValue(string $key, $default = null)
+    public function getParameterValue(string $key, mixed $default = null): mixed
     {
         return $this->parameterManager->get($key, $default);
     }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
         "symfony/validator": "^4.4 || ^5.0 || ^6.0",
         "twig/twig": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
-        "symfony/validator": "^4.4 || ^5.0 || ^6.0",
+        "symfony/framework-bundle": "^6.0 || ^7.0",
+        "symfony/validator": "^6.0 || ^7.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Changes:
- Eliminate deprecations for Symfony 6.4 [described in this issue](https://github.com/sherlockode/configuration-bundle/issues/83)
- Added support for PHP only versions above 8.0 (required to support Symfony ^6.0 || ^7.0)
- Added support for Symfony ^6.0 || ^7.0
- Added PHP typing wherever possible

I used current commenting standards in PHP, where if we have typing in the code, we do not duplicate it in comments.

The project would move forward if we started supporting Symfony 6.4 without any depreciated and Symfony 7.0.
I think it's a good idea, but it's up to the owner to decide.