### PR TITLE
Harden composer constraints for Symfony 6.4/7.x + PHP 8.2-8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "symfony/framework-bundle": "^6.0 || ^7.0",
-        "symfony/validator": "^6.0 || ^7.0",
+        "php": "^8.2",
+        "symfony/framework-bundle": "^6.4 || ^7.0",
+        "symfony/validator": "^6.4 || ^7.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6 || ^11.0"
     },
     "autoload": {
         "psr-4": { "Sherlockode\\ConfigurationBundle\\": "" }


### PR DESCRIPTION
- php: ^8.0 -> ^8.2 (Symfony 7 baseline, aligns with target PHP 8.4)
- framework-bundle/validator: ^6.0||^7.0 -> ^6.4||^7.0 (LTS floor)
- phpunit: ^9.6 -> ^9.6||^11.0 (PHP 8.4 toolchain support)

Code is already SF7-compatible upstream (native return types, #[AsCommand], typed Form types). This only tightens the manifest to the migration target.